### PR TITLE
Adding MIT license to the gemspec.

### DIFF
--- a/jimson-temp.gemspec
+++ b/jimson-temp.gemspec
@@ -4,6 +4,7 @@ spec = Gem::Specification.new do |s|
   s.author = "Chris Kite"
   s.homepage = "https://github.com/mindeavor/jimson.git"
   s.platform = Gem::Platform::RUBY
+  s.licenses = ["MIT"]
   s.summary = "JSON-RPC 2.0 client and server"
   s.require_path = "lib"
   s.has_rdoc = false


### PR DESCRIPTION
I'm working on [VersionEye](https://www.versioneye.com/) and my goal is to build up a license db for RubyGems which is complete. To reduce the manual work I'm doing currently it would be awesome if this gemspec would contain the license information in future. Many Thanks.
